### PR TITLE
Number notation does not requre spaces

### DIFF
--- a/index.html
+++ b/index.html
@@ -65,7 +65,7 @@
               Calculator is in <strong>BETA</strong>. Be wary of results. <a href="#calcDetails" data-toggle="collapse" role="button" aria-expanded="false" aria-controls="calcDetails" class="alert-link">(Details/Tips)</a>
               <div class="collapse" id="calcDetails"><div><strong>Details:</strong> The calculator does a basic simulation, normalizing each generator's output rate and running until the goal is met or it reaches 24h.  Normalizing averages out things like crits and long run speeds, which introduces some error.  The calculator currently does not take airdrops or unlocking new generators into account.  Please let me know if you find any issues or have any suggestions.</div>
                 <div><strong>Tips:</strong><ul>
-                  <li>Enter numbers like <code id="numberExample">1.52 AA</code> with a space in-between.  Periods and commas are based on your browser's locale settings.</li>
+                  <li>Enter numbers like <code id="numberExample">1.52 AA</code>.  Periods and commas are based on your browser's locale settings.</li>
                   <li>Leave <var>Speed</var> blank or <code>0</code> if not running, use <code>1</code> if you are manually running it constantly, <code>0.5</code> if you're manually running it half the time, etc.</li>
                 </ul></div>
               </div>

--- a/missions.js
+++ b/missions.js
@@ -620,12 +620,11 @@ function bigNum(x) {
 
 // Converts AdCom style numbers to normal. fromBigNum("1 CC") => 1E21
 function fromBigNum(x) {
-  // TODO: make a better regex that can pick up non-spaces maybe?
   if (x == null) {
     return NaN;
   }
 
-  let [,...split] = [.../(\d+(?:[\.,]\d+)?) ?(\w+)?/g.exec(x)]
+  let [,...split] = [.../(\d+(?:[\.,]\d+)?) ?(\w+)?/g.exec(x)].filter(x => x != undefined)
   
   if (split.length == 1) {
     return parseLocaleNumber(split[0]);

--- a/missions.js
+++ b/missions.js
@@ -624,7 +624,7 @@ function fromBigNum(x) {
     return NaN;
   }
 
-  let [,...split] = [.../(\d+(?:[\.,]\d+)?) ?(\w+)?/g.exec(x)].filter(x => x != undefined)
+  let split = x.length == 0 ? [""] : [.../(\d+(?:[\.,]\d+)?) ?(\w+)?/g.exec(x)].filter((x,i) => x != undefined && i>0)
   
   if (split.length == 1) {
     return parseLocaleNumber(split[0]);

--- a/missions.js
+++ b/missions.js
@@ -625,7 +625,7 @@ function fromBigNum(x) {
     return NaN;
   }
 
-  let [,...split2] = [.../(\d+(?:[\.,]\d+)?) ?(\w+)?/g.exec(x)]
+  let [,...split] = [.../(\d+(?:[\.,]\d+)?) ?(\w+)?/g.exec(x)]
   
   if (split.length == 1) {
     return parseLocaleNumber(split[0]);

--- a/missions.js
+++ b/missions.js
@@ -624,7 +624,7 @@ function fromBigNum(x) {
     return NaN;
   }
 
-  let split = x.length == 0 ? [""] : [.../(\d+(?:[\.,]\d+)?) ?(\w+)?/g.exec(x)].filter((x,i) => x != undefined && i>0)
+  let split = x.length == 0 ? [""] : /([\d\.,]+)/.test(x) ? [.../([\d\.,]+)? *(\w+)?/g.exec(x)].filter((y,i) => y != undefined && i>0) : NaN
   
   if (split.length == 1) {
     return parseLocaleNumber(split[0]);

--- a/missions.js
+++ b/missions.js
@@ -625,7 +625,7 @@ function fromBigNum(x) {
     return NaN;
   }
 
-  let split = x.toString().trim().split(/ +/);
+  let [,...split2] = [.../(\d+(?:[\.,]\d+)?) ?(\w+)?/g.exec(x)]
   
   if (split.length == 1) {
     return parseLocaleNumber(split[0]);


### PR DESCRIPTION
AdCom number types do not require a space so `1.23M` and `4CCC` is valid