### PR TITLE
Improve navbar layout

### DIFF
--- a/index.html
+++ b/index.html
@@ -26,27 +26,28 @@
         <a href="?rank=event" class="dropdown-item" id="mode-select-event">Event</a>
       </ul>
     </span>
-    <span class="mr-auto"></span>
-    <span class="dropdown">
-      <a class="nav-link dropdown-toggle" href="#" id="settingsDropdownMenuLink" role="button" data-toggle="dropdown" aria-haspopup="true" aria-expanded="false">
-        Settings
-      </a>
-      <ul class="dropdown-menu dropdown-menu-right" aria-labelledby="settingsDropdownMenuLink">
-        <h6 class="dropdown-header text-center">Icons</h6>
-        <button class="dropdown-item config-icon" id="config-icon-image" onclick="setIcons('image')">Images</button>
-        <button class="dropdown-item config-icon" id="config-icon-emoji" onclick="setIcons('emoji')">Emoji</button>
-        <button class="dropdown-item config-icon" id="config-icon-none" onclick="setIcons('none')">None</button>
-        <div class="dropdown-divider"></div>
-        <h6 class="dropdown-header text-center">Style</h6>
-        <button class="dropdown-item config-style" id="config-style-light" onclick="setStyle('light')">Light</button>
-        <button class="dropdown-item config-style" id="config-style-dark" onclick="setStyle('dark')">Dark</button>
-        <button class="dropdown-item" id="config-style-list" onclick="toggleListStyle()">List</button>
-        <div class="dropdown-divider"></div>
-        <h6 class="dropdown-header text-center">Progress</h6>
-        <button class="dropdown-item" onclick="advanceProgressTo()">Advance to...</button>
-        <button class="dropdown-item" onclick="resetProgress()">Reset</button>
-      </ul>
-    </span>
+    <ul class="navbar-nav ml-auto">
+      <li class="nav-item dropdown">
+        <a class="nav-link dropdown-toggle" href="#" id="settingsDropdownMenuLink" role="button" data-toggle="dropdown" aria-haspopup="true" aria-expanded="false">
+          Settings
+        </a>
+        <ul class="dropdown-menu dropdown-menu-right" aria-labelledby="settingsDropdownMenuLink">
+          <h6 class="dropdown-header text-center">Icons</h6>
+          <button class="dropdown-item config-icon" id="config-icon-image" onclick="setIcons('image')">Images</button>
+          <button class="dropdown-item config-icon" id="config-icon-emoji" onclick="setIcons('emoji')">Emoji</button>
+          <button class="dropdown-item config-icon" id="config-icon-none" onclick="setIcons('none')">None</button>
+          <div class="dropdown-divider"></div>
+          <h6 class="dropdown-header text-center">Style</h6>
+          <button class="dropdown-item config-style" id="config-style-light" onclick="setStyle('light')">Light</button>
+          <button class="dropdown-item config-style" id="config-style-dark" onclick="setStyle('dark')">Dark</button>
+          <button class="dropdown-item" id="config-style-list" onclick="toggleListStyle()">List</button>
+          <div class="dropdown-divider"></div>
+          <h6 class="dropdown-header text-center">Progress</h6>
+          <button class="dropdown-item" onclick="advanceProgressTo()">Advance to...</button>
+          <button class="dropdown-item" onclick="resetProgress()">Reset</button>
+        </ul>
+      </li>
+    </ul>
   </nav>
   <div class="modal fade" id="infoPopup" tabindex="-1" role="dialog" aria-labelledby="infoTitle" aria-hidden="true">
     <div class="modal-dialog" role="document">


### PR DESCRIPTION
This PR introduces the following changes:

- Improves the way the navbar is structured to follow the [Navbar guide](https://getbootstrap.com/docs/4.3/components/navbar/)
- Converts the "Settings" navigation link to an actual navigation item (such that it's styled correctly and for future work regarding the dark theme in a follow-up PR)

Here are some screenshots of what I've done:

![Navbar in light theme](https://user-images.githubusercontent.com/20047125/70859694-83f6f280-1f52-11ea-8031-d4dd2f826611.jpg)

![Navbar in dark theme](https://user-images.githubusercontent.com/20047125/70859697-8bb69700-1f52-11ea-878b-cb667af36801.jpg)

VS the previous appearance:

![Previous navbar in light theme](https://user-images.githubusercontent.com/20047125/70859710-b6a0eb00-1f52-11ea-922d-79ff9b2476f6.jpg)

![Previous navbar in dark theme](https://user-images.githubusercontent.com/20047125/70859713-ba347200-1f52-11ea-9d29-117615426087.jpg)
