### PR TITLE
Added descriptions for Crit Bonus and Discount researchers

### DIFF
--- a/missions.js
+++ b/missions.js
@@ -838,9 +838,31 @@ function getResearcherDetails(researcher) {
       break;
       
     case "GeneratorCostReduction":
-      // TODO once I implement Motherland
+      vals = [researcher.ExpoMultiplier * researcher.ExpoGrowth,
+              researcher.ExpoMultiplier * researcher.ExpoGrowth * researcher.ExpoGrowth,
+              researcher.ExpoMultiplier * researcher.ExpoGrowth * researcher.ExpoGrowth * researcher.ExpoGrowth];
+      // TargetIds[0] is a set of industries ("Baking, NorthPole, SnowArmy, SantaWorkshop")
+      resources = researcher.TargetIds[0].split(/, ?/).map(ind => resourceName(getResourceByIndustry(ind).Id));
+      if (resources.length == getData().Industries.length) {
+        return `Lowers cost of all generators by ${vals[0]}x/${vals[1]}x/${vals[2]}x/...`;
+      } else {
+        return `Lowers cost of every ${resources.join('/')}-industry generator by ${vals[0]}x/${vals[1]}x/${vals[2]}x/...`;
+      }
+      break;
+    
     case "GeneratorCritPowerMult":
-      // TODO once I implement Motherland
+      vals = [researcher.ExpoMultiplier * researcher.ExpoGrowth,
+              researcher.ExpoMultiplier * researcher.ExpoGrowth * researcher.ExpoGrowth,
+              researcher.ExpoMultiplier * researcher.ExpoGrowth * researcher.ExpoGrowth * researcher.ExpoGrowth];
+      // TargetIds[0] is a set of industries ("Baking, NorthPole, SnowArmy, SantaWorkshop")
+      resources = researcher.TargetIds[0].split(/, ?/).map(ind => resourceName(getResourceByIndustry(ind).Id));
+      if (resources.length == getData().Industries.length) {
+        return `Multiplies crit bonus of all generators by ${vals[0]}x/${vals[1]}x/${vals[2]}x/...`;
+      } else {
+        return `Multiplies crit bonus of every ${resources.join('/')}-industry generator by ${vals[0]}x/${vals[1]}x/${vals[2]}x/...`;
+      }
+      break;
+      
     case "GachaCardsPayoutMultiplier":
       // TODO once I implement Motherland
     case "GachaSciencePayoutMultiplier":


### PR DESCRIPTION
The current event features a Crit Bonus researcher that the tracker doesn't know how to describe.  I have fixed that and also included an implementation for Reduction.  Technically, this can't be seen anywhere on the tracker currently (the only potential place would be if it was motherland scripted mission reward, and they never are), but could be useful in the future.

<img width="452" alt="researcher-description-1" src="https://user-images.githubusercontent.com/7157178/71217467-c8e09900-2272-11ea-97ad-46023d31ac89.png">
<img width="269" alt="researcher-description-2" src="https://user-images.githubusercontent.com/7157178/71217478-d0a03d80-2272-11ea-9706-3ce183a8b2df.png">

