### PR TITLE
Fixed broken science icons in motherland

### DIFF
--- a/missions.js
+++ b/missions.js
@@ -737,7 +737,8 @@ function describeMission(mission, overrideIcon = "") {
       textHtml = `Collect Cards (${condition.Threshold})`;
       break;
     case "ResourcesSpentSinceSubscription":
-      iconHtml = getMissionIcon(condition.ConditionId, condition.ConditionType, overrideIcon, 'event');
+      let overrideDirectory = (currentMode == "event") ? "event" : "";  // Use /img/event/ of /img/event/theme/
+      iconHtml = getMissionIcon(condition.ConditionId, condition.ConditionType, overrideIcon, overrideDirectory);
       textHtml = `Spend ${resourceName(condition.ConditionId)} (${condition.Threshold})`;
       break;
     default:


### PR DESCRIPTION
The code was mistakenly trying to find to find motherland science icons at `/img/event/scientist.png` instead of `/img/main/scientist.png` because it was always overriding the image directory with `event` (which it needs to do for events since the icon is not theme-specific).  Now it will only do that if it is actually an event.