### PR TITLE
Up/down buttons for trades

### DIFF
--- a/missions.js
+++ b/missions.js
@@ -2218,16 +2218,15 @@ function getResourceInput(tagId, description, imageUrl, imageTitle, defaultValue
     postSpanHtml = `</a>`;
   }
 
-  // DRS 2021-11-12
-  // Extending this method by adding in up/down buttons for trade. Look up the trade name based on positional value in tagId.
+  // Trade up/down button implementation. Trade name is queried based on positional value in tagId.
   if (tagId.indexOf("trade") !== -1) {
     let tradeName = tagId.substr(0, tagId.indexOf("-"));
     tradeDeltaButtons = `<div id="${tradeName}-buttons" class="tradeLevelButtonGroup">
       <div id="${tradeName}-up-button" class="tradeLevelButton float-left text-success">
-        <a onclick="tradeLevelDelta('${tradeName}', 1)" role="button" title="Increase ${tradeName} trade">&#x25B2;</a>
+        <a onclick="tradeLevelDelta('${tradeName}', 1)" role="button" title="Increase ${resourceName(tradeName, false)} trade">&#x25B2;</a>
       </div>
       <div id="${tradeName}-down-button" class="tradeLevelButton float-right text-danger">
-        <a onclick="tradeLevelDelta('${tradeName}', -1)" role="button" title="Decrease ${tradeName} trade">&#x25BC;</a>
+        <a onclick="tradeLevelDelta('${tradeName}', -1)" role="button" title="Decrease ${resourceName(tradeName, false)} trade">&#x25BC;</a>
       </div>
     </div>`;
   }
@@ -2782,7 +2781,6 @@ function getTradesTab() {
   return html;
 }
 
-// DRS 2021-11-12
 // Adjusts the trade level based on the DOM input.
 function tradeLevelDelta(tradeId, delta) {
   let inputToBigNum = fromBigNum($(`#${tradeId}-trade-cost`).val());

--- a/missions_base.css
+++ b/missions_base.css
@@ -249,9 +249,13 @@ input:checked + .slider:before {
   bottom: 2.5em;
 }
 
+.researcherLevelButton {
+  border: 1px outset;
+  border-radius: 3px;
+}
+
 .researcherLevelButton, .tradeLevelButton {
   width: 1em;
-  border: 1px outset;
 }
 
 .researcherLevelButton:hover, .tradeLevelButton:hover {
@@ -259,12 +263,13 @@ input:checked + .slider:before {
 }
 
 /*
-  DRS 2021-11-12
   Custom styling for trade level buttons.
 */
 .tradeLevelButton {
   position: absolute;
   height: 50%;
+  margin-left: 2px;
+  line-height: 20px;
 }
 
 .tradeLevelButton:nth-child(2) {

--- a/missions_base.css
+++ b/missions_base.css
@@ -249,13 +249,26 @@ input:checked + .slider:before {
   bottom: 2.5em;
 }
 
-.researcherLevelButton {
+.researcherLevelButton, .tradeLevelButton {
   width: 1em;
   border: 1px outset;
 }
 
-.researcherLevelButton:hover {
+.researcherLevelButton:hover, .tradeLevelButton:hover {
   cursor: pointer;
+}
+
+/*
+  DRS 2021-11-12
+  Custom styling for trade level buttons.
+*/
+.tradeLevelButton {
+  position: absolute;
+  height: 50%;
+}
+
+.tradeLevelButton:nth-child(2) {
+  top: 50%;
 }
 
 .missionContainer {


### PR DESCRIPTION
The comrade trade menu now has up/down buttons for the input box. Responsive for desktop and mobile devices and handles incorrect input gracefully.
![comradetrade](https://user-images.githubusercontent.com/45662167/142495477-efd926a8-9559-479b-84fa-1e01a8cc2040.png)
